### PR TITLE
[beakjoon-kyeong] 파이프옮기기_17070.java

### DIFF
--- a/baekjoon/bokyeong/파이프옮기기_17070.java
+++ b/baekjoon/bokyeong/파이프옮기기_17070.java
@@ -1,0 +1,59 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	
+	static int N, ans;
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		int[][] map = new int[N+1][N+1];
+		for (int r = 1; r <= N; r++) {
+			st = new StringTokenizer(br.readLine());
+			for (int c = 1; c <= N; c++) {
+				map[r][c] = Integer.parseInt(st.nextToken());
+			}
+		}
+		
+		bfs(map, 1, 2, 0);
+		System.out.println(ans);
+	}
+	
+	// status 가로 0 세로 1 대각선 2
+	public static void bfs (int[][] map, int r, int c, int status) {
+		if (r == N && c == N) {
+			ans++;
+			return;
+		}
+		
+		// 가로
+		if (status != 1) {
+			int nr = r;
+			int nc = c + 1;
+			if (nc <= N && map[nr][nc] == 0) {
+				bfs(map, nr, nc, 0);
+			}
+		}
+		
+		// 세로
+		if (status != 0) {
+			int nr = r + 1;
+			int nc = c;
+			if (nr <= N && map[nr][nc] == 0) {
+				bfs(map, nr, nc, 1);
+			}
+		}
+		
+		// 대각선
+		int nr = r + 1;
+		int nc = c + 1;
+		if (nr <= N && nc <= N && map[nr][nc] == 0 && map[r][nc] == 0 && map[nr][c] == 0) {
+			bfs(map, nr, nc, 2);
+		}
+	}
+}


### PR DESCRIPTION
이 문제는 실제 A형에서는 기차로 나왔는데 파이프로만 살짝 바꿔서 백준에 올라왔다고 들었습니다!

이전 상태 (가로인지, 세로인지, 대각선인지)를 기억하고 있어야하기 때문에 bfs 방식으로 풀었습니다.
가로, 세로, 오른쪽 대각선으로만 갈 수 있기 때문에 이전에 방문한 곳에 다시 방문할 방법은 없어서 이전에 방문한 적이  있는지 확인하는 로직은 과감히 뺐습니다.
변수 nr,nc는 재사용빈도가 많지 않아서 사용하지 않아도 무방할 것 같지만 가독성을 높이는 측면에서 사용했습니다.
